### PR TITLE
Remove duplicate types from print_formatter

### DIFF
--- a/zpr.h
+++ b/zpr.h
@@ -1112,7 +1112,6 @@ namespace zpr
 	template <typename T>
 	struct print_formatter<T, typename std::enable_if<(
 		std::is_same_v<T, char*> ||
-		std::is_same_v<T, char const*> ||
 		std::is_same_v<T, const char*> ||
 		std::is_same_v<T, const char* const>
 	)>::type>


### PR DESCRIPTION
In `print_formatter` template specializations for `const char*` and `char const*` declare the same type, so I removed one of them.